### PR TITLE
change hipster_mvc local file path to remote git repo in pubspec.yml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_comics
 dependencies:
   hipster_mvc:
-    path: /home/chris/repos/hipster-mvc
+    git: git@github.com:eee-c/hipster-mvc.git
   browser: any
   dirty: any
   uuid: any


### PR DESCRIPTION
was just following along "Dart 1 for everyone" and encounterd this issue that 'pub install' wouldn't work out of the box on a fresh git clone of dart-comics.
